### PR TITLE
Github Actions: Check Degenbot python versions and dependencies

### DIFF
--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -41,9 +41,6 @@ jobs:
         - name: Brownie version
           run: brownie --version
 
-        - name: Ape Framework version
-          run: ape --version
-
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7.16', '3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
         - name: Setup files
@@ -37,6 +37,9 @@ jobs:
 
         - name: Rename requirements.txt
           run: mv requirements.txt requirements_${{ matrix.os }}_${{ matrix.python-version }}.txt
+
+        - name: Brownie version
+          run: brownie --version
 
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7.16', '3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
         - name: Setup files

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -1,0 +1,41 @@
+name: Check Dependencies
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7.16', '3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+        - name: Setup files
+          uses: actions/checkout@v3
+        - name: Setup Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v4
+          with:
+            python-version: ${{ matrix.python-version }}
+            cache: 'pip'
+        - name: Install dependencies
+          run: | 
+            python -m pip install --upgrade pip
+            pip install pip-tools
+            if [ -f requirements.in ]; then pip-compile; fi
+            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        - name: Rename requirements.txt
+          run: mv requirements.txt requirements_${{ matrix.python-version }}.txt
+        - name: Add to Degenbot
+          run: |
+            git add requirements_${{ matrix.python-version }}.txt
+            git commit -m 'Update Requirements'
+            git push origin main
+        - name: Upload requirements.txt
+          uses: actions/upload-artifact@v3
+          with:
+            name: requirements_${{ matrix.python-version }}
+            path: requirements_${{ matrix.python-version }}.txt

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -25,7 +25,7 @@ jobs:
           run: | 
             pip install --upgrade pip
             pip install pip-tools
-            if [ -f requirements.in ]; then pip-compile; fi
+            if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         - name: Rename requirements.txt
           run: mv requirements.txt requirements_${{ matrix.python-version }}.txt

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7.16', '3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
+        python-version: ['3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -23,7 +23,7 @@ jobs:
             cache: 'pip'
         - name: Install dependencies
           run: | 
-            python -m pip install --upgrade pip
+            pip install --upgrade pip
             pip install pip-tools
             if [ -f requirements.in ]; then pip-compile; fi
             if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -41,6 +41,9 @@ jobs:
         - name: Brownie version
           run: brownie --version
 
+        - name: Ape Framework version
+          run: ape --version
+
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  check:
+  check_dependencies:
     strategy:
       fail-fast: false
       matrix:
@@ -16,26 +16,30 @@ jobs:
     steps:
         - name: Setup files
           uses: actions/checkout@v3
+
         - name: Setup Python ${{ matrix.python-version }}
           uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
             cache: 'pip'
+
+        - name: Upgrade pip
+          run: pip install --upgrade pip
+
+        - name: Install pip-tools
+          run: pip install pip-tools
+
+        - name: Run pip-compile
+          run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
+
         - name: Install dependencies
-          run: | 
-            pip install --upgrade pip
-            pip install pip-tools
-            if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
-            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
         - name: Rename requirements.txt
-          run: mv requirements.txt requirements_${{ matrix.python-version }}.txt
-        - name: Add to Degenbot
-          run: |
-            git add requirements_${{ matrix.python-version }}.txt
-            git commit -m 'Update Requirements'
-            git push origin main
+          run: mv requirements.txt requirements_${{ matrix.os }}_${{ matrix.python-version }}.txt
+
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3
           with:
-            name: requirements_${{ matrix.python-version }}
-            path: requirements_${{ matrix.python-version }}.txt
+            name: requirements_${{ matrix.os }}_${{ matrix.python-version }}
+            path: requirements_${{ matrix.os }}_${{ matrix.python-version }}.txt

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,5 @@ matplotlib
 networkx
 scipy
 titanoboa
+vyper
+eth-ape

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+cython
 eth-brownie
 eth-abi
 requests

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,9 @@
+eth-brownie
+eth-abi
+requests
+web3
+websockets
+matplotlib
+networkx
+scipy
+titanoboa

--- a/requirements.in
+++ b/requirements.in
@@ -9,4 +9,3 @@ networkx
 scipy
 titanoboa
 vyper
-eth-ape


### PR DESCRIPTION
This workflow will trigger for each commit done to main branch.

The goal of this workflow is to check Degenbot's dependencies against different python versions and OS.

The workflow can be updated by adding new dependencies in the `requirements.in` or new python versions in the workflows' `matrix` variable.

This way we can confidently update our working environments without fear of breaking Degenbot.

The workflow will generate `requirements_{{OS}}_{{python_version}}_.txt` for each valid build.
It can be downloaded from the `Actions` tab.

TODO:

- Merge `requirements_{{OS}}_{{python_version}}_.txt` directly to the repo.

