### PR TITLE
Updated workflow for new Python versions.

### DIFF
--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -33,8 +33,8 @@ jobs:
           if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
 
-        - name: Run pip-compile
-          if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version == '3.11.5' }}
+        - name: Run pip-compile 2
+          if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version }} == '3.11.5'
           run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -34,7 +34,7 @@ jobs:
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
 
         - name: Run pip-compile
-          if: ${{ matrix.python-version == '3.10.13' || matrix.python-version == '3.11.5' }}
+          if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version == '3.11.5' }}
           run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -30,7 +30,7 @@ jobs:
           run: pip install pip-tools
 
         - name: Run pip-compile
-          if: ${{ matrix.python-version == '3.8.18' || matrix.python-version == '3.9.8' }}
+          if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
 
         - name: Run pip-compile

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -29,12 +29,12 @@ jobs:
         - name: Install pip-tools
           run: pip install pip-tools
 
-        - if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
-          name: Run pip-compile
+        - name: Run pip-compile
+          if: ${{ matrix.python-version == '3.8.18' || matrix.python-version == '3.9.8' }}
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
 
-        - if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version }} == '3.11.5'
-          name: Run pip-compile
+        - name: Run pip-compile
+          if: ${{ matrix.python-version == '3.10.13' || matrix.python-version == '3.11.5' }}
           run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8.16', '3.9.16', '3.10.11', '3.11.1', '3.11.2', '3.11.3']
+        python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.15']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.15']
+        python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.5']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -30,7 +30,7 @@ jobs:
           run: pip install pip-tools
 
         - name: Run pip-compile ${{ matrix.python-version }}
-          run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
+          run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies
           run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -29,11 +29,11 @@ jobs:
         - name: Install pip-tools
           run: pip install pip-tools
 
-        - name: Run pip-compile
+        - name: Run pip-compile ${{ matrix.python-version }}
           if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
 
-        - name: Run pip-compile 2
+        - name: Run pip-compile ${{ matrix.python-version }}
           if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version }} == '3.11.5'
           run: if [ -f requirements.in ]; then pip-compile; fi
 

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -29,11 +29,14 @@ jobs:
         - name: Install pip-tools
           run: pip install pip-tools
 
+        - name: Cython fix for python 3.10+
+          run: echo "Cython<3" > cython_constraint.txt 
+
         - name: Run pip-compile ${{ matrix.python-version }}
-          run: if [ -f requirements.in ]; then pip-compile; fi
+          run: if [ -f requirements.in ]; then PIP_CONSTRAINT=cython_constraint.txt pip-compile; fi
 
         - name: Install dependencies
-          run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          run: if [ -f requirements.txt ]; then PIP_CONSTRAINT=cython_constraint.txt pip install -r requirements.txt; fi
 
         - name: Rename requirements.txt
           run: mv requirements.txt requirements_${{ matrix.os }}_${{ matrix.python-version }}.txt

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -30,12 +30,7 @@ jobs:
           run: pip install pip-tools
 
         - name: Run pip-compile ${{ matrix.python-version }}
-          if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
-
-        - name: Run pip-compile ${{ matrix.python-version }}
-          if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version }} == '3.11.5'
-          run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies
           run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -47,7 +47,7 @@ jobs:
           run: brownie --version
         
         - name: Update websockets
-          run: pip install websockets --updgrade
+          run: pip install websockets --upgrade
 
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3

--- a/.github/workflows/degenbot_check_dependencies.yaml
+++ b/.github/workflows/degenbot_check_dependencies.yaml
@@ -29,8 +29,13 @@ jobs:
         - name: Install pip-tools
           run: pip install pip-tools
 
-        - name: Run pip-compile
+        - if: ${{ matrix.python-version }} == '3.8.18' || ${{ matrix.python-version }} == '3.9.8'
+          name: Run pip-compile
           run: if [ -f requirements.in ]; then pip-compile --resolver=backtracking; fi
+
+        - if: ${{ matrix.python-version }} == '3.10.13' || ${{ matrix.python-version }} == '3.11.5'
+          name: Run pip-compile
+          run: if [ -f requirements.in ]; then pip-compile; fi
 
         - name: Install dependencies
           run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
@@ -40,6 +45,9 @@ jobs:
 
         - name: Brownie version
           run: brownie --version
+        
+        - name: Update websockets
+          run: pip install websockets --updgrade
 
         - name: Upload requirements.txt
           uses: actions/upload-artifact@v3

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-cython
 eth-brownie
 eth-abi
 requests
@@ -7,5 +6,4 @@ websockets
 matplotlib
 networkx
 scipy
-titanoboa
 vyper

--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,4 @@ matplotlib
 networkx
 scipy
 vyper
+titanoboa


### PR DESCRIPTION
Fixed the issues with python 3.10 based on the following web page

- https://discuss.python.org/t/getting-requirements-to-build-wheel-did-not-run-successfully-exit-code-1/30365

```
I believe this is due to the recent release of Cython 3.0.0, which the package you’re installing apparently isn’t ready for :slight_smile:

Try the following:

$ echo "Cython<3" > cython_constraint.txt
$ PIP_CONSTRAINT=cython_constraint.txt pip install "ai-core-sdk[aicore-content]"

Note that you need to set the constraint file via the environment variable so that it propagates to the build env.
```

Python 3.11 still failing installing the following packages 
```bash
 ERROR: Could not build wheels for bitarray, cytoolz, yarl, which is required to install pyproject.toml-based projects
```

Probably it will fix itself as soon as new versions get out.