### PR TITLE
Don't set_web3 in every import degenbot

### DIFF
--- a/src/degenbot/config.py
+++ b/src/degenbot/config.py
@@ -5,10 +5,26 @@ from web3 import Web3
 
 from .logging import logger
 
-_web3: Web3
+_web3: Web3 = None
 
 
 def get_web3() -> Web3:
+    if _web3 is None:
+        if "brownie" in sys.modules:  # pragma: no cover
+            logger.info("Brownie detected. Degenbot will attempt to use its Web3 object...")
+            from brownie import web3 as brownie_web3  # type: ignore[import]
+
+            set_web3(brownie_web3)
+
+        else:
+            logger.info("Attempting to use Web3 AutoProvider")
+            try:
+                set_web3(Web3())
+            except Exception as e:
+                logger.error(e)
+                logger.info(
+                    "Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use"
+                )
     return _web3
 
 
@@ -34,19 +50,4 @@ def set_web3(w3: Web3):
     global _web3
     _web3 = w3
 
-if not _web3:
-    if "brownie" in sys.modules:  # pragma: no cover
-        logger.info("Brownie detected. Degenbot will attempt to use its Web3 object...")
-        from brownie import web3 as brownie_web3  # type: ignore[import]
-    
-        set_web3(brownie_web3)
-    
-    else:
-        logger.info("Attempting to use Web3 AutoProvider")
-        try:
-            set_web3(Web3())
-        except Exception as e:
-            logger.error(e)
-            logger.info(
-                "Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use"
-            )
+

--- a/src/degenbot/config.py
+++ b/src/degenbot/config.py
@@ -34,19 +34,19 @@ def set_web3(w3: Web3):
     global _web3
     _web3 = w3
 
-
-if "brownie" in sys.modules:  # pragma: no cover
-    logger.info("Brownie detected. Degenbot will attempt to use its Web3 object...")
-    from brownie import web3 as brownie_web3  # type: ignore[import]
-
-    set_web3(brownie_web3)
-
-else:
-    logger.info("Attempting to use Web3 AutoProvider")
-    try:
-        set_web3(Web3())
-    except Exception as e:
-        logger.error(e)
-        logger.info(
-            "Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use"
-        )
+if not _web3:
+    if "brownie" in sys.modules:  # pragma: no cover
+        logger.info("Brownie detected. Degenbot will attempt to use its Web3 object...")
+        from brownie import web3 as brownie_web3  # type: ignore[import]
+    
+        set_web3(brownie_web3)
+    
+    else:
+        logger.info("Attempting to use Web3 AutoProvider")
+        try:
+            set_web3(Web3())
+        except Exception as e:
+            logger.error(e)
+            logger.info(
+                "Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use"
+            )


### PR DESCRIPTION
We don't need to set new web3 provider in every `import degenbot`. 
Otherwise, I see:

```
Connected to Web3 provider RPC connection http://localhost:8547
```
then many times:

```
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Attempting to use Web3 AutoProvider
Attempting to use Web3 AutoProvider
Attempting to use Web3 AutoProvider
Attempting to use Web3 AutoProvider
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
Attempting to use Web3 AutoProvider
Web3 object is not connected.
Could not establish Web3 connection using AutoProvider. Provide a Web3 instance to set_web3() before use
```