### PR TITLE
Fix double recalculate arbitrage

### DIFF
--- a/src/degenbot/arbitrage/uniswap_lp_cycle.py
+++ b/src/degenbot/arbitrage/uniswap_lp_cycle.py
@@ -483,8 +483,6 @@ class UniswapLpCycle(Subscriber, ArbitrageHelper):
             ]
         ] = None,
     ) -> ArbitrageCalculationResult:
-        self._pre_calculation_check(override_state)
-
         state_overrides = self._sort_overrides(override_state)
 
         # bound the amount to be swapped

--- a/src/degenbot/arbitrage/uniswap_lp_cycle.py
+++ b/src/degenbot/arbitrage/uniswap_lp_cycle.py
@@ -682,7 +682,7 @@ class UniswapLpCycle(Subscriber, ArbitrageHelper):
         """
         TBD
         """
-
+        self._pre_calculation_check(override_state)
         result = self._calculate(override_state=override_state)
 
         if override_state is None:


### PR DESCRIPTION
According to this fix, https://github.com/BowTiedDevil/degenbot/commit/84dd8d4d3a073a01ce3d7fa9c1729c5ab22d2768

There are supposing the:

- `calculate`, `calculate_arbitrage`, `calculate_with_pool` must have the `self._pre_calculation_check(override_state)`
- `_calculate` mustn't have the `_pre_calculation_check`