### PR TITLE
fix(registry): prevent V4 pool registration from polluting _all_pools

### DIFF
--- a/src/degenbot/registry/pool.py
+++ b/src/degenbot/registry/pool.py
@@ -143,13 +143,13 @@ class PoolRegistry(AbstractRegistry):
                 pool_manager_address=get_checksum_address(pool_address),
                 pool_id=pool_id,
             )
-        elif self.get(
-            chain_id=chain_id,
-            pool_address=get_checksum_address(pool_address),
-        ):
-            raise degenbot.exceptions.DegenbotValueError(message="Pool is already registered")
-
-        self._all_pools[chain_id, get_checksum_address(pool_address)] = pool
+        else:
+            if self.get(
+                chain_id=chain_id,
+                pool_address=get_checksum_address(pool_address),
+            ):
+                raise degenbot.exceptions.DegenbotValueError(message="Pool is already registered")
+            self._all_pools[chain_id, get_checksum_address(pool_address)] = pool
 
     def remove(
         self,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -172,3 +172,64 @@ def test_v4_pool_add_and_removal():
         pool_address="0x0000000000000000000000000000000000000000",
         pool_id="0x0000000000000000000000000000000000000000000000000000000000000000",
     )
+
+
+def test_v4_add_does_not_pollute_main_registry():
+    """
+    A V4 pool registration must write to the V4 sub-registry only — never to ``_all_pools``.
+
+    The V4 ``PoolManager`` is a singleton on-chain; many V4 pools share the same contract
+    address and are distinguished only by ``pool_id``. Writing the manager address into
+    ``_all_pools`` (which is keyed only by chain+address) collapses them to a single slot
+    and the last registered pool overwrites all earlier entries.
+    """
+    fake_pool_manager_address = "0x1234567890123456789012345678901234567890"
+    fake_pool_id = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    chain_id = 1
+
+    fake_pool = FakeUniswapV4Pool(
+        address=fake_pool_manager_address,
+        pool_id=fake_pool_id,
+    )
+
+    pool_registry.add(
+        pool=fake_pool,
+        chain_id=chain_id,
+        pool_address=fake_pool_manager_address,
+        pool_id=fake_pool_id,
+    )
+
+    # Lookup without pool_id must not see V4 pools.
+    assert (
+        pool_registry.get(
+            chain_id=chain_id,
+            pool_address=fake_pool_manager_address,
+        )
+        is None
+    )
+
+    # _all_pools must not be polluted by the V4 registration.
+    assert (
+        chain_id,
+        get_checksum_address(fake_pool_manager_address),
+    ) not in pool_registry._all_pools
+
+
+def test_v4_pools_with_same_manager_distinct_ids_coexist():
+    """
+    Two V4 pools sharing one ``PoolManager`` but with distinct ``pool_id``s must both
+    remain accessible after registration.
+    """
+    manager = "0x1234567890123456789012345678901234567890"
+    pool_id_a = "0x" + "a" * 64
+    pool_id_b = "0x" + "b" * 64
+    chain_id = 1
+
+    pool_a = FakeUniswapV4Pool(address=manager, pool_id=pool_id_a)
+    pool_b = FakeUniswapV4Pool(address=manager, pool_id=pool_id_b)
+
+    pool_registry.add(pool=pool_a, chain_id=chain_id, pool_address=manager, pool_id=pool_id_a)
+    pool_registry.add(pool=pool_b, chain_id=chain_id, pool_address=manager, pool_id=pool_id_b)
+
+    assert pool_registry.get(chain_id=chain_id, pool_address=manager, pool_id=pool_id_a) is pool_a
+    assert pool_registry.get(chain_id=chain_id, pool_address=manager, pool_id=pool_id_b) is pool_b


### PR DESCRIPTION
## Summary

`PoolRegistry.add` unconditionally writes `_all_pools[(chain, pool_address)] = pool` after delegating V4 registrations to the V4 sub-registry — line 152 sits outside the `if/elif`. For Uniswap V4, `pool_address` is the singleton `PoolManager` address, so:

- every V4 pool sharing one manager clobbers the same `_all_pools` slot;
- a V4 manager address shadows any non-V4 pool that happens to live at the same `(chain, address)` key;
- `pool_registry.get(chain, pool_manager_address)` (without `pool_id`) returns whichever V4 pool was registered last — not `None` as one would expect.

## Fix

Restructure `add()` into an explicit `if/else`, matching the symmetrical structure already used by `remove()` and `get()`. The `_all_pools` write only fires on the non-V4 path.

## Test plan

- [x] New `test_v4_add_does_not_pollute_main_registry` fails on `main`, passes on this branch.
- [x] New `test_v4_pools_with_same_manager_distinct_ids_coexist` documents the V4 invariant (regression guard).
- [x] Existing `test_v4_pool_add_and_removal` still passes.
- [x] `ruff check` + `ruff format --check` + `mypy src/degenbot/registry/pool.py` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)